### PR TITLE
Fix title failing to link

### DIFF
--- a/src/templates/aboutpage.html
+++ b/src/templates/aboutpage.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="../">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="../favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">

--- a/src/templates/allartwork.html
+++ b/src/templates/allartwork.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="../../">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="../../favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">

--- a/src/templates/allaudio.html
+++ b/src/templates/allaudio.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="../../">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="../../favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">

--- a/src/templates/allposts.html
+++ b/src/templates/allposts.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="../../">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="../../favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">

--- a/src/templates/artpage.html
+++ b/src/templates/artpage.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="../../">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="../../favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">

--- a/src/templates/audiopage.html
+++ b/src/templates/audiopage.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="../../">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="../../favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -22,9 +22,7 @@
 
 <body>
     <main>
-        <header>
-            <h1><a href="./">Adam Lastowka</a></h1>
-        </header>
+        {% block header %}{% endblock %}
         <section id="nav">
             {% block nav_links %}{% endblock %}
         </section>

--- a/src/templates/homepage.html
+++ b/src/templates/homepage.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="./">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="./favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon">

--- a/src/templates/post.html
+++ b/src/templates/post.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="../../">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="../../favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">

--- a/src/templates/qapage.html
+++ b/src/templates/qapage.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block header %}
+<header>
+    <h1><a href="../">Adam Lastowka</a></h1>
+</header>
+{% endblock %}
+
 {% block favicon_and_stylesheet %}
 <link rel="icon" href="../favicon.ico" type="image/x-icon">
 <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">


### PR DESCRIPTION
Should resolve, moved the title out of the base template so I can do relative links in the page templates. Relative links should eventually be handled in a cleaner way by the renderer. Resolves https://github.com/Rachmanin0xFF/Rachmanin0xFF.github.io/issues/3